### PR TITLE
[Fix] A bug that load waiting widget is too big

### DIFF
--- a/src/libcalamaresui/widgets/WaitingWidget.cpp
+++ b/src/libcalamaresui/widgets/WaitingWidget.cpp
@@ -36,10 +36,10 @@ WaitingWidget::WaitingWidget( const QString& text, QWidget* parent )
 
     int spnrSize = m_waitingLabel->fontMetrics().height() * 4;
     spnr->setFixedSize( spnrSize, spnrSize );
-    spnr->setInnerRadius( spnrSize );
+    spnr->setInnerRadius( spnrSize / 2 );
     spnr->setRoundness( 0 );
     spnr->setLineLength( spnrSize / 2 );
-    spnr->setLineWidth( spnrSize / 10 );
+    spnr->setLineWidth( spnrSize / 16 );
     spnr->setColor(QColor("#009aff"));
     spnr->start();
 


### PR DESCRIPTION
起動直後に表示される読み込み中のウィジェットが大きすぎる問題が修正される・・・かも・・・
サイズを小さくしました

![image](https://user-images.githubusercontent.com/36789813/102552781-1bae9400-4105-11eb-8d34-20597f5d1acc.png)
